### PR TITLE
Default Field Support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 group 'com.github.sidhant92'
-version = "1.0.0"
+version = "1.1.0"
 
 apply plugin: "com.dipien.semantic-version"
 

--- a/src/main/java/com/github/sidhant92/boolparser/application/BooleanExpressionEvaluator.java
+++ b/src/main/java/com/github/sidhant92/boolparser/application/BooleanExpressionEvaluator.java
@@ -34,9 +34,13 @@ public class BooleanExpressionEvaluator {
         operatorService = new OperatorService();
     }
 
-    public Try<Boolean> evaluate(final String expression, final Map<String, Object> data) {
-        final Try<Node> tokenOptional = boolExpressionParser.parseExpression(expression);
+    public Try<Boolean> evaluate(final String expression, final Map<String, Object> data, final String defaultField) {
+        final Try<Node> tokenOptional = boolExpressionParser.parseExpression(expression, defaultField);
         return tokenOptional.map(node -> evaluateToken(node, data));
+    }
+
+    public Try<Boolean> evaluate(final String expression, final Map<String, Object> data) {
+        return evaluate(expression, data, null);
     }
 
     private boolean evaluateToken(final Node node, final Map<String, Object> data) {

--- a/src/main/java/com/github/sidhant92/boolparser/parser/BoolExpressionParser.java
+++ b/src/main/java/com/github/sidhant92/boolparser/parser/BoolExpressionParser.java
@@ -9,4 +9,6 @@ import io.vavr.control.Try;
  */
 public interface BoolExpressionParser {
     Try<Node> parseExpression(final String expression);
+
+    Try<Node> parseExpression(final String expression, final String defaultField);
 }

--- a/src/test/java/com/github/sidhant92/boolparser/application/BooleanExpressionEvaluatorTest.java
+++ b/src/test/java/com/github/sidhant92/boolparser/application/BooleanExpressionEvaluatorTest.java
@@ -419,4 +419,22 @@ public class BooleanExpressionEvaluatorTest {
         assertTrue(booleanOptional.isSuccess());
         assertTrue(booleanOptional.get());
     }
+
+    @Test
+    public void testDefaultFieldTrue() {
+        final Map<String, Object> data = new HashMap<>();
+        data.put("age", 19);
+        final Try<Boolean> booleanOptional = booleanExpressionEvaluator.evaluate(">= 18 AND < 20", data, "age");
+        assertTrue(booleanOptional.isSuccess());
+        assertTrue(booleanOptional.get());
+    }
+
+    @Test
+    public void testDefaultFieldFalse() {
+        final Map<String, Object> data = new HashMap<>();
+        data.put("age", 17);
+        final Try<Boolean> booleanOptional = booleanExpressionEvaluator.evaluate(">= 18 AND < 20", data, "age");
+        assertTrue(booleanOptional.isSuccess());
+        assertFalse(booleanOptional.get());
+    }
 }


### PR DESCRIPTION
Adds support for having default field if a field is not mentioned in the expression.

Example:

> 18 AND < 25.

Here you can pass a default field which gets applied to all the comparisons.