### PR TITLE
Cached Bool Parser

### DIFF
--- a/src/main/java/com/github/sidhant92/boolparser/parser/antlr/BoolParser.java
+++ b/src/main/java/com/github/sidhant92/boolparser/parser/antlr/BoolParser.java
@@ -4,28 +4,16 @@ import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.ParseTreeWalker;
-import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.sidhant92.boolparser.domain.Node;
 import com.github.sidhant92.boolparser.operator.OperatorFactory;
 import com.github.sidhant92.boolparser.parser.BoolExpressionParser;
 import io.vavr.control.Try;
 
 public class BoolParser implements BoolExpressionParser {
-    private boolean useCache;
-
-    private Cache<String, Node> cache;
-
     private final ParseTreeWalker parseTreeWalker = new ParseTreeWalker();
 
     public BoolParser() {
         OperatorFactory.initialize();
-    }
-
-    public BoolParser(final int maxCacheSize) {
-        OperatorFactory.initialize();
-        this.useCache = true;
-        this.cache = Caffeine.newBuilder().maximumSize(maxCacheSize).build();
     }
 
     @Override
@@ -39,13 +27,10 @@ public class BoolParser implements BoolExpressionParser {
     }
 
     private Node getNode(final String expression, final String defaultField) {
-        if (useCache) {
-            return cache.get(expression, ex -> parse(ex, defaultField));
-        }
         return parse(expression, defaultField);
     }
 
-    private Node parse(final String expression, final String defaultField) {
+    protected Node parse(final String expression, final String defaultField) {
         final BooleanExpressionLexer filterLexer = new BooleanExpressionLexer(CharStreams.fromString(expression));
         final CommonTokenStream commonTokenStream = new CommonTokenStream(filterLexer);
         final BooleanExpressionParser filterParser = new BooleanExpressionParser(commonTokenStream);

--- a/src/main/java/com/github/sidhant92/boolparser/parser/antlr/CachedBoolParser.java
+++ b/src/main/java/com/github/sidhant92/boolparser/parser/antlr/CachedBoolParser.java
@@ -1,0 +1,30 @@
+package com.github.sidhant92.boolparser.parser.antlr;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.sidhant92.boolparser.domain.Node;
+import com.github.sidhant92.boolparser.operator.OperatorFactory;
+import io.vavr.control.Try;
+
+public class CachedBoolParser extends BoolParser {
+    private final Cache<String, Node> cache;
+
+    public CachedBoolParser(final int maxCacheSize) {
+        OperatorFactory.initialize();
+        this.cache = Caffeine.newBuilder().maximumSize(maxCacheSize).build();
+    }
+
+    @Override
+    public Try<Node> parseExpression(final String expression, final String defaultField) {
+        return Try.of(() -> getNode(expression, defaultField));
+    }
+
+    @Override
+    public Try<Node> parseExpression(final String expression) {
+        return Try.of(() -> getNode(expression, null));
+    }
+
+    private Node getNode(final String expression, final String defaultField) {
+        return cache.get(expression, ex -> super.parse(ex, defaultField));
+    }
+}


### PR DESCRIPTION
BREAKING CHANGE:

Now to use caching in Bool Parser we need to use `CachedBoolParser` instead of passing the boolean field in the constructor of BoolParser.